### PR TITLE
Download size of package.json dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,13 @@ async function main () {
 
         try {
           const pkgJSON = fs.readFileSync(pkgJSONPath, {encoding: 'utf8'})
-          console.log(pkgJSON)
+          const { dependencies, devDependencies } = JSON.parse(pkgJSON)
+
+          const deps = transformDepsObjToArray(dependencies)
+          const devDeps = transformDepsObjToArray(devDependencies)
+
+          console.log(deps)
+          console.log(devDeps)
         } catch (err) {
           console.error('' + err)
         }
@@ -40,6 +46,15 @@ async function main () {
     }
   }
   clearInterval(interval)
+}
+
+/**
+ * Transform a dependency obj like `{"autopefixer": "^9.8.6", ...}`
+ * into an array `["autoprefixer@^9.8.6", ...]`
+ */
+function transformDepsObjToArray (deps) {
+  if (!deps) return []
+  return Object.entries(deps).map(([pkgName, version]) => `${pkgName}@${version}`)
 }
 
 function request (pkgName) {

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ async function main () {
           const devDeps = transformDepsObjToArray(devDependencies)
 
           console.log(`"${pkgJSONPath}" dependencies:`)
-          if (!deps.length) console.log("None")
+          if (!deps.length) console.log('None')
           else {
             for (const dep of deps) {
               total += await getPackageSize(dep)
@@ -45,12 +45,20 @@ async function main () {
               total += await getPackageSize(devDep)
             }
           }
+          console.log() // newline
         } catch (err) {
           console.error('' + err)
         }
-        continue
       }
-      total += await getPackageSize(argv[i])
+      else {
+        total += await getPackageSize(argv[i])
+        // Log newline if this is the last arg
+        // or the next arg is -f or --file
+        const j = i+1
+        if (j === argv.length || argv[j] === '-f' || argv[j] === '--file') {
+          console.log()
+        }
+      }
     }
     console.log(`Total size: ${total} bytes`)
   }

--- a/index.js
+++ b/index.js
@@ -12,12 +12,14 @@ let interval = setInterval(() => {
 main()
 
 async function main () {
-  if (process.argv.length < 3 || process.argv[2] === '--help') {
+  const { argv } = process;
+  if (argv.length < 3 || argv[2] === '--help') {
     console.log('Usage: download-size package-name [another-package ...]')
   } else {
-    for (let i = 2; i < process.argv.length; i++) {
+    let total = 0;
+    for (let i = 2; i < argv.length; i++) {
       try {
-        let result = await request(process.argv[i])
+        let result = await request(argv[i])
         process.stdout.write('\b')  // backspace
         console.log(`${result.name}@${result.version}: ${result.prettySize}`)
       } catch (err) {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,11 @@ async function main () {
   } else {
     let total = 0;
     for (let i = 2; i < argv.length; i++) {
+      if (argv[i] === "-f" || argv[i] === "--file") {
+        // The next arg must be a path to a package.json file
+        const pkgJSONPath = argv[++i];
+        console.log(pkgJSONPath)
+      }
       try {
         let result = await request(argv[i])
         process.stdout.write('\b')  // backspace

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ async function main () {
             }
           }
 
-          console.log(`"${pkgJSONPath}" devDependencies:`)
+          console.log(`\n"${pkgJSONPath}" devDependencies:`)
           if (!devDeps.length) console.log("None")
           else {
             for (const devDep of devDeps) {

--- a/index.js
+++ b/index.js
@@ -37,17 +37,20 @@ async function main () {
               total += await getPackageSize(dep)
             }
           }
+
+          console.log(`"${pkgJSONPath}" devDependencies:`)
+          if (!devDeps.length) console.log("None")
+          else {
+            for (const devDep of devDeps) {
+              total += await getPackageSize(devDep)
+            }
+          }
         } catch (err) {
           console.error('' + err)
         }
+        continue
       }
-      // try {
-      //   let result = await request(argv[i])
-      //   process.stdout.write('\b')  // backspace
-      //   console.log(`${result.name}@${result.version}: ${result.prettySize}`)
-      // } catch (err) {
-      //   console.error('' + err)
-      // }
+      total += await getPackageSize(argv[i])
     }
   }
   clearInterval(interval)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const https = require('https')
+const fs = require('fs')
 
 let spinners = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
 let interval = setInterval(() => {
@@ -18,18 +19,24 @@ async function main () {
   } else {
     let total = 0;
     for (let i = 2; i < argv.length; i++) {
-      if (argv[i] === "-f" || argv[i] === "--file") {
+      if (argv[i] === '-f' || argv[i] === '--file') {
         // The next arg must be a path to a package.json file
-        const pkgJSONPath = argv[++i];
-        console.log(pkgJSONPath)
+        const pkgJSONPath = argv[++i]
+
+        try {
+          const pkgJSON = fs.readFileSync(pkgJSONPath, {encoding: 'utf8'})
+          console.log(pkgJSON)
+        } catch (err) {
+          console.error('' + err)
+        }
       }
-      try {
-        let result = await request(argv[i])
-        process.stdout.write('\b')  // backspace
-        console.log(`${result.name}@${result.version}: ${result.prettySize}`)
-      } catch (err) {
-        console.error('' + err)
-      }
+      // try {
+      //   let result = await request(argv[i])
+      //   process.stdout.write('\b')  // backspace
+      //   console.log(`${result.name}@${result.version}: ${result.prettySize}`)
+      // } catch (err) {
+      //   console.error('' + err)
+      // }
     }
   }
   clearInterval(interval)

--- a/index.js
+++ b/index.js
@@ -34,10 +34,7 @@ async function main () {
           if (!deps.length) console.log("None")
           else {
             for (const dep of deps) {
-              let result = await request(dep)
-              total += result.size
-              process.stdout.write('\b')  // backspace
-              console.log(`${result.name}@${result.version}: ${result.prettySize} -- ${result.size}`)
+              total += await getPackageSize(dep)
             }
           }
         } catch (err) {
@@ -63,6 +60,23 @@ async function main () {
 function transformDepsObjToArray (deps) {
   if (!deps) return []
   return Object.entries(deps).map(([pkgName, version]) => `${pkgName}@${version}`)
+}
+
+/**
+ * Get the size of a package and log it
+ * @return the size of the package
+ */
+async function getPackageSize(pkgName) {
+  let size = 0
+  try {
+    let result = await request(pkgName)
+    size = result.size
+    process.stdout.write('\b')  // backspace
+    console.log(`${result.name}@${result.version}: ${result.prettySize}`)
+  } catch (err) {
+    console.error('' + err)
+  }
+  return size
 }
 
 function request (pkgName) {

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ async function main () {
       }
       total += await getPackageSize(argv[i])
     }
+    console.log(`Total size: ${total} bytes`)
   }
   clearInterval(interval)
 }

--- a/index.js
+++ b/index.js
@@ -30,8 +30,16 @@ async function main () {
           const deps = transformDepsObjToArray(dependencies)
           const devDeps = transformDepsObjToArray(devDependencies)
 
-          console.log(deps)
-          console.log(devDeps)
+          console.log(`"${pkgJSONPath}" dependencies:`)
+          if (!deps.length) console.log("None")
+          else {
+            for (const dep of deps) {
+              let result = await request(dep)
+              total += result.size
+              process.stdout.write('\b')  // backspace
+              console.log(`${result.name}@${result.version}: ${result.prettySize} -- ${result.size}`)
+            }
+          }
         } catch (err) {
           console.error('' + err)
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "download-size",
   "version": "1.3.5",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "si-prefix": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/si-prefix/-/si-prefix-0.2.0.tgz",
+      "integrity": "sha512-GpIuMuJyg2GKjboWH5hyR/VRlVi3UoDQGrlQPKCeNmKkDQJ6o8HZbLSGTZyJcHym1ZEnkQHuqNd+cELxV+U11g=="
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "preversion": "npm test",
     "postpublish": "git push && git push --tags",
-    "test": "node index.js async && node index.js @angular/core"
+    "test": "node index.js async && node index.js @angular/core && node index.js --file ./package.json"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
   "scripts": {
     "preversion": "npm test",
     "postpublish": "git push && git push --tags",
-    "test": "node index.js async && node index.js @angular/core && node index.js --file ./package.json"
+    "test": "npm run test:single && npm run test:multiple && npm run test:no-package && npm run test:no-file",
+    "test:single" : "node index.js async",
+    "test:multiple" : "node index.js async -f package.json @angular/core",
+    "test:no-package" : "node index.js asdfnjjqjwjjds",
+    "test:no-file" : "node index.js -f missing-file.json"
   },
   "repository": {
     "type": "git",
@@ -26,5 +30,7 @@
     "url": "https://github.com/arve0/download-size/issues"
   },
   "homepage": "https://github.com/arve0/download-size#readme",
-  "dependencies": {}
+  "dependencies": {
+    "si-prefix": "^0.2.0"
+  }
 }


### PR DESCRIPTION
This should resolve #9 

Here's what I got when testing:

* package.json without dependencies:
```shell
$ node index.js -f package.json
"package.json" dependencies:
None

"package.json" devDependencies:
None

Total size: 0 bytes
```

* package.json with dependencies:
```shell
$ node index.js -f test/package.json
"test/package.json" dependencies:
autoprefixer@9.8.6: 829.58 KiB
parcel-bundler@1.12.4: 14.19 MiB
postcss-modules@3.2.2: 640.74 KiB
tailwindcss@1.7.6: 3.33 MiB

"test/package.json" devDependencies:
stylelint-config-recommended@3.0.0: 2.64 KiB

Total size: 19879005 bytes
```

* package.json with the usual package arguments
```shell
$ node index.js autoprefixer -f test/package.json react react-dom
autoprefixer@9.8.6: 829.58 KiB

"test/package.json" dependencies:
autoprefixer@9.8.6: 829.58 KiB
parcel-bundler@1.12.4: 14.19 MiB
postcss-modules@3.2.2: 640.74 KiB
tailwindcss@1.7.6: 3.33 MiB

"test/package.json" devDependencies:
stylelint-config-recommended@3.0.0: 2.64 KiB

react@16.13.1: 93.23 KiB
react-dom@16.13.1: 794.74 KiB

Total size: 21637770 bytes
```

* Invalid package.json path:
```shell
$ node index.js -f abc/package.json
Error: ENOENT: no such file or directory, open 'abc/package.json'
Total size: 0 bytes
```

* Long option `--file` also works
```shell
$ node index.js --file test/package.json
"test/package.json" dependencies:
autoprefixer@9.8.6: 829.58 KiB
parcel-bundler@1.12.4: 14.19 MiB
postcss-modules@3.2.2: 640.74 KiB
tailwindcss@1.7.6: 3.33 MiB

"test/package.json" devDependencies:
stylelint-config-recommended@3.0.0: 2.64 KiB

Total size: 19879005 bytes
```

**Notes**
1. I changed the option from `-p` in the original issue to `-f` (as in "file"), with the long option `--file`.
2. The total size shows in bytes. Please how do I make it more readable, like "17 KB", "23 MB", etc.?

Also, if there's anything I didn't do right, please let me know. Thank you @arve0.